### PR TITLE
Modified SearchParameter interface

### DIFF
--- a/src/main/java/ge/rrs/FreeSearchParameter.java
+++ b/src/main/java/ge/rrs/FreeSearchParameter.java
@@ -47,6 +47,18 @@ public class FreeSearchParameter implements SearchParameter {
         return value;
     }
 
+    public String getValueExpression() throws Exception {
+        if (isEmpty())
+            throw new Exception("Unable to access value expression: the parameter is empty.");
+        return "?";
+    }
+
+    public String[] getValueArgs() throws Exception {
+        if (isEmpty())
+            throw new Exception("Unable to access value args: the parameter is empty.");
+        return new String[]{ getValue() };
+    }
+
     public String getRelation() throws Exception {
         if (isEmpty())
             throw new Exception("Unable to access relation: the parameter is empty.");

--- a/src/main/java/ge/rrs/RoomSearchParameter.java
+++ b/src/main/java/ge/rrs/RoomSearchParameter.java
@@ -4,13 +4,22 @@ package ge.rrs;
 public class RoomSearchParameter implements SearchParameter {
     // Search parameters
     private String key;
-    private String value;
     private String relation;
+    private String valueExpression;
+    private String[] args;
 
-    RoomSearchParameter(String key, String relation, String value) {
+    /**
+     * Initializes Room Search parameter.
+     * @param key The key of the query.
+     * @param relation Relation between the key and value.
+     * @param valueExpression Expression, with arguments replaced with '?'
+     * @param args Arguments.
+     */
+    RoomSearchParameter(String key, String relation, String valueExpression, String[] args) {
         this.key = key;
         this.relation = relation;
-        this.value = value;
+        this.valueExpression = valueExpression;
+        this.args = args;
     }
 
     /**
@@ -21,10 +30,9 @@ public class RoomSearchParameter implements SearchParameter {
      * @return: Room Search Parameter.
      */
     static RoomSearchParameter fromFloorRange(int start, int end) {
-        // TODO: fix this.
         RoomSearchParameter param = new RoomSearchParameter(
-            "floor", " BETWEEN ", String.format(
-                "%d AND %d", start, end));
+            "floor", " BETWEEN ", "? AND ?", new String[] {
+                ""+start, ""+end});
         return param;
     }
 
@@ -35,7 +43,18 @@ public class RoomSearchParameter implements SearchParameter {
 
     @Override
     public String getValue() throws Exception {
-        return value;
+        return String.format(
+            valueExpression.replace("?", "%s"), (Object[])args);
+    }
+
+    @Override
+    public String getValueExpression() throws Exception {
+        return valueExpression;
+    }
+
+    @Override
+    public String[] getValueArgs() throws Exception {
+        return args;
     }
 
     @Override

--- a/src/main/java/ge/rrs/SearchParameter.java
+++ b/src/main/java/ge/rrs/SearchParameter.java
@@ -20,6 +20,20 @@ public interface SearchParameter {
     public String getValue() throws Exception;
 
     /**
+     * @return Value where all arguments
+     *  are replaced with placeholders.
+     * @throws Exception
+     */
+    public String getValueExpression() throws Exception;
+
+    /**
+     * @return Arguments which are to be
+     *  placed into the value expression.
+     * @throws Exception
+     */
+    public String[] getValueArgs() throws Exception;
+
+    /**
      * @return an operator that corresponds
      *  to the relation between the key and
      *  the value to be used for search. 

--- a/src/main/java/ge/rrs/TableEntry.java
+++ b/src/main/java/ge/rrs/TableEntry.java
@@ -4,6 +4,7 @@ package ge.rrs;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -42,8 +43,11 @@ public abstract class TableEntry {
             try {
                 searchQuery =
                     param.getKey() +
-                    param.getRelation() + "?";
-                args.add(param.getValue());
+                    param.getRelation() +
+                    param.getValueExpression();
+                args.addAll(
+                    Arrays.asList(
+                        param.getValueArgs()));
             } catch (Exception _) {
                 continue;
             }

--- a/src/test/java/ge/rrs/RoomSearchParamTest.java
+++ b/src/test/java/ge/rrs/RoomSearchParamTest.java
@@ -1,0 +1,14 @@
+package ge.rrs;
+
+// JUnit
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.*;
+
+public class RoomSearchParamTest {
+    @Test
+    public void testValueParsing() throws Exception {
+        RoomSearchParameter param = new RoomSearchParameter(
+            "", "", "? ?", new String[] {"A", "BC"});
+        assertEquals("A BC", param.getValue());
+    }    
+}


### PR DESCRIPTION
The `SearchParameter` interface now distinguishes value expressions from their arguments, hence the `getValue()` is no longer used in the SQL commands.